### PR TITLE
Speed up apktool: skip resources, we don't need them anyway

### DIFF
--- a/main/detect.py
+++ b/main/detect.py
@@ -196,7 +196,7 @@ class Detector:
         :return: decoded files' path
         """
         self.time_load_and_extract.start()
-        cmd = self.project_path + "/" + "../tool/apktool decode %s -o " % path + self.project_path + "/" + \
+        cmd = self.project_path + "/" + "../tool/apktool decode -r %s -o " % path + self.project_path + "/" + \
             "../decoded/%s" % os.path.basename(path)
         subprocess.call(cmd, shell=True)
         return self.project_path + '/../decoded/%s' % os.path.basename(path)


### PR DESCRIPTION
side effect: working around a current bug, see [Error with animated vector drawble](https://github.com/iBotPeaches/Apktool/issues/1456).

For me that was the main reason – and the speedup the side effect. We don't need the "resources" (drawables etc) to identify *function calls* (and *package* names), do we? Cuts processing time down considerably (felt like factor 2+, but I didn't measure it). You might wish to port this to V2 as well, it's just 3 characters to add to the `apktool` call :smiley_cat: 